### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Feel free to open issues for any features requests or bugs you find!
 ## Running
 
 ```bash
-cargo run --release exabind
+cargo run --release
 ```
 
 ## Usage


### PR DESCRIPTION
Not 100% this is just my machine, but if I run `cargo run --release exabind` I get the following error: `error: unexpected argument 'exabind' found`

Therefore I ran just `cargo run --release` which worked straight away.


Fedora 40, cargo 1.82.0